### PR TITLE
Fix Markdown for header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#First Aid git
+# First Aid git
 
 ## How to run
 


### PR DESCRIPTION
There was a space missing after the hash sign, so that the header did not parse correctly.
